### PR TITLE
Changes to dependencies for Rails 3 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gemspec
 gem 'right_support', '~> 2.14'
 
 # Gems used by reusable spec helpers
-gem "builder", "~> 3.0"
+gem "builder", "2.1.2"
 
 # Gems used by the command-line Git tools
 gem 'trollop', ['>= 1.0', '< 3.0']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    right_develop (3.2.1)
-      builder (~> 3.0)
+    right_develop (3.3.0.pre.rc.1)
+      builder (>= 2.1.2)
       rack
       right_aws (>= 2.1.0)
       right_git (>= 1.0)
@@ -17,7 +17,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    builder (3.2.3)
+    builder (2.1.2)
     byebug (9.0.6)
     coderay (1.1.1)
     coveralls (0.8.20)
@@ -91,7 +91,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
-  builder (~> 3.0)
+  builder (= 2.1.2)
   coveralls
   cucumber (~> 1.0, < 1.3.3)
   libxml-ruby (~> 2.7)
@@ -111,4 +111,4 @@ DEPENDENCIES
   trollop (>= 1.0, < 3.0)
 
 BUNDLED WITH
-   1.14.6
+   1.17.3

--- a/lib/right_develop/version.rb
+++ b/lib/right_develop/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module RightDevelop
-  VERSION = '3.2.1'.freeze
+  VERSION = '3.3.0-rc.1'.freeze
 end

--- a/right_develop.gemspec
+++ b/right_develop.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new('~> 2.1')
 
   spec.add_runtime_dependency(%q<right_support>, ['~> 2.14'])
-  spec.add_runtime_dependency(%q<builder>, ["~> 3.0"])
+  spec.add_runtime_dependency(%q<builder>, [">= 2.1.2"])
   spec.add_runtime_dependency(%q<trollop>, ["< 3.0", ">= 1.0"])
   spec.add_runtime_dependency(%q<right_git>, [">= 1.0"])
   spec.add_runtime_dependency(%q<right_aws>, [">= 2.1.0"])


### PR DESCRIPTION
Removes the reliance on http://gems.test.rightscale.com/ and changes the net-ssh dependency to allow for usage in Rails 3 projects